### PR TITLE
Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+- '10'
+cache:
+  directories:
+  - node_modules
+script: 'true'
+deploy:
+  skip_cleanup: true
+  provider: npm
+  email: mail@stevetaylor.io
+  api_key:
+    secure: YcmT6C5vaXZhRmJglcDEBrme6ew+q65jA0ZFZi9Zd//cLCYK5Aq0jZXy38f463iDqloHjZ36U94wFfRWP4rWUHGZM8fswcTNGBjvTNgOT53mWTl46gg+0lcYV7/g1csO3ZKsy3nG1VkJSF1COf96YImQqgkSx5zWEeAnNrV68edAMLpbu2EVqNihYLO9sfpcEmq4yj9mwY0Muwrim0Xo+0dop0EKLRzcPITplNkkF3l4wexb60M1fhP7I3ZRZjCVcaeBj3W/OfJ/SjVI/D30P4Do43KVCK7okHUK4R72vi8ZWTOmZnVXiqQ1MAPLry0jGs8k77++AKhzn9g7Y5OeB4YmTlz7toqLuLFhXxuZBiAHyCyQpv4xZSTWaZNWh/KeFJkRe/bXSQJdG885+mrWouG3I8UQzHWhIs3cGEF/8N3IYEZC4swUw9PQUSwJFcxe0+BSgF1ZpuvsbzFcedAgxorC6kLMTKUdEsCcLTf8I9MTBBn19QYBBAmuSaKJ6A9XeybV6k40kz6wyM8e+j9mMluYdLM0L5xtalr8EQk5hZSFzCdBshNDDMXngUeIRhMOyOXbUly/Tt2QfVmE0RVeaeuC5GljCMihrOB1P4RwJ1plgsVOPc0sJkkzFwTEWNLHxnhN4JNy9kBbgJu+/SIC3ap+4XVL1+amDiSIxqMx9oY=
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A common usage is as follows:
 You have a file called `my-button.viz.js` :
 ```jsx harmony
 describe('MyButton', function () {
-    it('disabled', async function (target) {
+    test('disabled', async function (target) {
         // Asynchronously render the component inside the target dom element
         await new Promise((resolve) => ReactDOM.render(<MyButton disabled={true}/>, target, resolve));
 
@@ -22,7 +22,7 @@ describe('MyButton', function () {
 });
 ```
 
-As a third parameter, both `describe` and `it` can also take a third parameter of options to specify viewport sizes at which the screenshots should be taken:
+As a third parameter, both `describe` and `test` can also take a third parameter of options to specify viewport sizes at which the screenshots should be taken:
 ```jsx harmony
 const options = {
     viewportWidths: [320, 768, 1024],
@@ -34,7 +34,9 @@ describe('MyButton', function () {
 }, options);
 ```
 
-Entries in an `options` object provided to an `it` function will override any the option passed to the `describe` funciton, if any. 
+Entries in an `options` object provided to a `test` function will override any the option passed to the `describe` function, if any.
+
+You can use `it` instead of `test`. They are the same function.
 
 ### Making golden screenshots
 Here we define a "source of truth" against which future tests will be compared.
@@ -64,7 +66,7 @@ vizard test
 ```
 
 ## Configuration
-You can configure vizard by writing a `.vizardrc` or a `vizard.json` file in your project's root.
+You can configure Vizard by writing a `vizard.json`, `.vizardrc`, `.vizard.js` or `vizard.js` file in your project's root.
 Valid configuration options are as follows:
 
 * `chromeExecutablePath`: Optional path to your Chrome executable, defaults to the output of `which google-chrome-beta`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vizard",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,26 +34,17 @@
     },
     "JSONStream": {
       "version": "1.3.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha1-MgjB8I06TZkmGrZPkjArwV4RHKA=",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
       }
     },
-    "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-      "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
-      }
-    },
     "acorn": {
       "version": "7.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha1-lJ028sKSU12mAig1hsJHfFfrLWw="
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -74,8 +65,8 @@
     },
     "acorn-node": {
       "version": "1.8.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha1-EUyV1kU55T3t4j3oudlt98euKvg=",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
       "requires": {
         "acorn": "^7.0.0",
         "acorn-walk": "^7.0.0",
@@ -84,20 +75,15 @@
       "dependencies": {
         "xtend": {
           "version": "4.0.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         }
       }
     },
     "acorn-walk": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/acorn-walk/-/acorn-walk-7.0.0.tgz",
-      "integrity": "sha1-yLpvDxqsSwqeMtHwrxK+dpUo82s="
-    },
-    "address": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-      "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz",
+      "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -125,30 +111,6 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
-    "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "requires": {
-        "string-width": "^2.0.0"
-      }
-    },
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -158,7 +120,8 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -178,16 +141,6 @@
         "normalize-path": "^2.1.1"
       }
     },
-    "arch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
-    },
-    "arg": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
-      "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w=="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -195,29 +148,6 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "args": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/args/-/args-4.0.0.tgz",
-      "integrity": "sha512-4b7lVF58nlo7sNtq8s2OueroOY/UHn0Nt/NVjsx9zn28u6yDVb9bQ/uy/5jKtHCbUDil4MlMyDLF5+OHEgnTug==",
-      "requires": {
-        "camelcase": "5.0.0",
-        "chalk": "2.3.2",
-        "leven": "2.1.0",
-        "mri": "1.1.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.3.2",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "aria-query": {
@@ -283,8 +213,8 @@
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -293,8 +223,8 @@
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "requires": {
         "object-assign": "^4.1.1",
         "util": "0.10.3"
@@ -302,12 +232,12 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -413,6 +343,11 @@
         }
       }
     },
+    "babelify": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+      "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -481,23 +416,8 @@
     },
     "base64-js": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE="
-    },
-    "basic-auth": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
-      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        }
-      }
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "binary-extensions": {
       "version": "1.12.0",
@@ -508,33 +428,13 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
-    },
-    "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-      "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        }
-      }
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -576,13 +476,13 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-pack": {
       "version": "6.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browser-pack/-/browser-pack-6.1.0.tgz",
-      "integrity": "sha1-w0uhDQuc4WK1ryJ8cTHJLC7NV3Q=",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "requires": {
         "JSONStream": "^1.0.3",
         "combine-source-map": "~0.8.0",
@@ -594,23 +494,23 @@
     },
     "browser-resolve": {
       "version": "1.11.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browser-resolve/-/browser-resolve-1.11.3.tgz",
-      "integrity": "sha1-m3y7PQ9RDky4a9vXlhJNKLWJCvY=",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
       "requires": {
         "resolve": "1.1.7"
       },
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
     },
     "browserify": {
       "version": "16.5.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browserify/-/browserify-16.5.0.tgz",
-      "integrity": "sha1-ocK8BDG+wR/SkVGUFYLj9kXt6IE=",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.0.tgz",
+      "integrity": "sha512-6bfI3cl76YLAnCZ75AGu/XPOsqUhRyc0F/olGIJeCxtfxF2HvPKEcmjU9M8oAPxl4uBY1U7Nry33Q6koV3f2iw==",
       "requires": {
         "JSONStream": "^1.0.3",
         "assert": "^1.4.0",
@@ -664,8 +564,8 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -677,8 +577,8 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -687,8 +587,8 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -698,7 +598,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -707,7 +607,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
         "bn.js": "^4.1.1",
@@ -721,8 +621,8 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
         "pako": "~1.0.5"
       }
@@ -741,8 +641,8 @@
     },
     "buffer": {
       "version": "5.4.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/buffer/-/buffer-5.4.3.tgz",
-      "integrity": "sha1-P7ycaetxPTI+P8Gole7gcQwHIRU=",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -755,7 +655,7 @@
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-modules": {
@@ -765,7 +665,7 @@
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "bytes": {
@@ -792,8 +692,8 @@
     },
     "cached-path-relative": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
-      "integrity": "sha1-oT30GW0md2IgzDNW6xR6Utuixts="
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg=="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -810,11 +710,6 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
-    "camelcase": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
-    },
     "caniuse-db": {
       "version": "1.0.30000912",
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000912.tgz",
@@ -828,16 +723,6 @@
       "integrity": "sha512-M3zAtV36U+xw5mMROlTXpAHClmPAor6GPKAMD5Yi7glCB5sbMPFtnQ3rGpk4XqPdUrrTIaVYSJZxREZWNy8QJg==",
       "dev": true,
       "optional": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
     },
     "chalk": {
       "version": "2.4.1",
@@ -856,30 +741,37 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
+        "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
+        "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
       }
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -914,11 +806,6 @@
         }
       }
     },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -933,60 +820,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
-    },
-    "clipboardy": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
-      "requires": {
-        "arch": "^2.1.0",
-        "execa": "^0.8.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        }
-      }
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "optional": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "optional": true
-        }
-      }
     },
     "co": {
       "version": "4.6.0",
@@ -1026,7 +859,7 @@
     },
     "combine-source-map": {
       "version": "0.8.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "requires": {
         "convert-source-map": "~1.1.0",
@@ -1048,50 +881,6 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
-    "compressible": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
-      "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
-      "requires": {
-        "mime-db": ">= 1.36.0 < 2"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
-        }
-      }
-    },
-    "compression": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
-      "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
-      "requires": {
-        "accepts": "~1.3.5",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.14",
-        "debug": "2.6.9",
-        "on-headers": "~1.0.1",
-        "safe-buffer": "5.1.2",
-        "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1110,7 +899,7 @@
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
         "date-now": "^0.1.4"
@@ -1118,7 +907,7 @@
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
     "contains-path": {
@@ -1128,14 +917,14 @@
       "dev": true,
       "optional": true
     },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "convert-source-map": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
     },
     "copy-descriptor": {
@@ -1157,8 +946,8 @@
     },
     "create-ecdh": {
       "version": "4.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
@@ -1166,8 +955,8 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -1178,8 +967,8 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -1203,8 +992,8 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -1235,15 +1024,10 @@
       "dev": true,
       "optional": true
     },
-    "dargs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-      "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
-    },
     "dash-ast": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/dash-ast/-/dash-ast-1.0.0.tgz",
-      "integrity": "sha1-EgKbpfsviqbwqGF5WyPBtLbCfTc="
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA=="
     },
     "date-format": {
       "version": "0.0.2",
@@ -1252,7 +1036,7 @@
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "debug": {
@@ -1262,12 +1046,6 @@
       "requires": {
         "ms": "^2.1.1"
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "optional": true
     },
     "decode-tiff": {
       "version": "0.2.1",
@@ -1279,11 +1057,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1351,14 +1124,9 @@
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
-    "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-    },
     "deps-sort": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/deps-sort/-/deps-sort-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "requires": {
         "JSONStream": "^1.0.3",
@@ -1369,46 +1137,17 @@
     },
     "des.js": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/des.js/-/des.js-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "detect-port": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.3.tgz",
-      "integrity": "sha512-IDbrX6PxqnYy8jV4wSHBaJlErYKTJvW8OQb9F7xivl1iQLqiUYHGa+nZ61Do6+N5uuOn/pReXKNqI9rUn04vug==",
-      "requires": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "detective": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/detective/-/detective-5.2.0.tgz",
-      "integrity": "sha1-/rKnfoW5BOzepFmtiXzJCpm9Kns=",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+      "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
       "requires": {
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
@@ -1417,8 +1156,8 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -1436,21 +1175,16 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto="
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "requires": {
         "readable-stream": "^2.0.2"
       }
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
       "version": "1.3.84",
@@ -1461,8 +1195,8 @@
     },
     "elliptic": {
       "version": "6.5.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/elliptic/-/elliptic-6.5.1.tgz",
-      "integrity": "sha1-w4D1+Qm/G5tEKNAozRjTsO/WtSs=",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+      "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -1479,11 +1213,6 @@
       "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
       "dev": true,
       "optional": true
-    },
-    "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "envify": {
       "version": "4.1.0",
@@ -1610,11 +1339,6 @@
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1948,11 +1672,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -1966,42 +1685,16 @@
     },
     "events": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/events/-/events-2.1.0.tgz",
-      "integrity": "sha1-KpoeGOYQbg6BKqnr1KgZs8KcC6U="
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
       }
     },
     "exit-hook": {
@@ -2215,6 +1908,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "requires": {
+        "punycode": "^1.3.2"
+      }
+    },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -2241,11 +1942,6 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
-    },
-    "filesize": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -2319,11 +2015,6 @@
         "map-cache": "^0.2.2"
       }
     },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
     "front-matter": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.2.tgz",
@@ -2353,6 +2044,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
       "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -2365,14 +2057,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2394,7 +2086,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2420,7 +2112,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2450,16 +2142,16 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2508,7 +2200,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2528,12 +2220,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -2598,17 +2290,17 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2626,35 +2318,35 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -2671,13 +2363,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2754,12 +2446,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -2789,16 +2481,16 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2816,7 +2508,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2869,17 +2561,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -2890,12 +2582,12 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -2905,7 +2597,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2951,18 +2643,13 @@
     },
     "get-assigned-identifiers": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
-      "integrity": "sha1-bb9BHeZIy6+NkWnrsNLVdhkeL/E="
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="
     },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
       "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
       "version": "2.0.6",
@@ -3051,27 +2738,6 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3141,7 +2807,7 @@
     },
     "hash-base": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/hash-base/-/hash-base-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
         "inherits": "^2.0.1",
@@ -3150,8 +2816,8 @@
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -3159,7 +2825,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
         "hash.js": "^1.0.3",
@@ -3174,23 +2840,12 @@
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
-    },
-    "http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "requires": {
-        "depd": "1.1.1",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": ">= 1.3.1 < 2"
-      }
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "https-proxy-agent": {
@@ -3205,12 +2860,13 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q="
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "3.3.10",
@@ -3250,14 +2906,9 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
     "inline-source-map": {
       "version": "0.6.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "requires": {
         "source-map": "~0.5.3"
@@ -3287,8 +2938,8 @@
     },
     "insert-module-globals": {
       "version": "7.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
-      "integrity": "sha1-7IfltCcoR54ye9XFxxYR3ftHUro=",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
+      "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
       "requires": {
         "JSONStream": "^1.0.3",
         "acorn-node": "^1.5.2",
@@ -3301,11 +2952,6 @@
         "undeclared-identifiers": "^1.1.2",
         "xtend": "^4.0.0"
       }
-    },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3401,7 +3047,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.0",
@@ -3478,11 +3125,6 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -3496,11 +3138,6 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
-    },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
       "version": "1.0.0",
@@ -3530,9 +3167,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3552,7 +3189,7 @@
     },
     "json-stable-stringify": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "requires": {
         "jsonify": "~0.0.0"
@@ -3568,6 +3205,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -3579,7 +3217,7 @@
     },
     "jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonpointer": {
@@ -3620,6 +3258,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3633,23 +3272,12 @@
     },
     "labeled-stream-splicer": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
-      "integrity": "sha1-QqQaFqvNRv0EYwbPTyw1dv/7HCE=",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+      "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
       "requires": {
         "inherits": "^2.0.1",
         "stream-splicer": "^2.0.0"
       }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "optional": true
-    },
-    "leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
     "levn": {
       "version": "0.3.0",
@@ -3711,12 +3339,6 @@
       "dev": true,
       "optional": true
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -3726,7 +3348,7 @@
     },
     "lodash.memoize": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
     },
     "lodash.snakecase": {
@@ -3767,12 +3389,6 @@
         }
       }
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3787,6 +3403,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
       "integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^3.0.2"
@@ -3809,8 +3426,8 @@
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -3838,38 +3455,6 @@
       "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true,
       "optional": true
-    },
-    "micro": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/micro/-/micro-9.3.1.tgz",
-      "integrity": "sha512-83uimpPJqfwkfKvJl2WWontBlV3hmzrIgyJ+L2uhDXKNk7Ll+/ezK3zBz7TljubpKPqjM0JdT2Ker4MTPmhjgA==",
-      "requires": {
-        "arg": "2.0.0",
-        "chalk": "2.4.0",
-        "content-type": "1.0.4",
-        "is-stream": "1.1.0",
-        "raw-body": "2.3.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
-      }
-    },
-    "micro-compress": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micro-compress/-/micro-compress-1.0.0.tgz",
-      "integrity": "sha1-U/WoC0rQMgyhZaVZtuPfFF1PcE8=",
-      "requires": {
-        "compression": "^1.6.2"
-      }
     },
     "micromatch": {
       "version": "3.1.10",
@@ -3902,8 +3487,8 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -3935,12 +3520,12 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
@@ -3957,9 +3542,9 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -3994,8 +3579,8 @@
     },
     "module-deps": {
       "version": "6.2.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/module-deps/-/module-deps-6.2.1.tgz",
-      "integrity": "sha1-z+VYeEBg6SaCT0dLTmRyh4N82lA=",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.1.tgz",
+      "integrity": "sha512-UnEn6Ah36Tu4jFiBbJVUtt0h+iXqxpLqDvPS8nllbw5RZFmNJ1+Mz5BjYnM9ieH80zyxHkARGLnMIHlPK5bu6A==",
       "requires": {
         "JSONStream": "^1.0.3",
         "browser-resolve": "^1.7.0",
@@ -4014,11 +3599,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "mri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.0.tgz",
-      "integrity": "sha1-XAo/KcjM/7ux7JQdzsCdcfoy82o="
-    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -4031,9 +3611,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
@@ -4070,11 +3650,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -4095,11 +3670,6 @@
       "requires": {
         "semver": "^5.3.0"
       }
-    },
-    "node-version": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.1.3.tgz",
-      "integrity": "sha512-rEwE51JWn0yN3Wl5BXeGn5d52OGbSXzWiiXRjAQeuyvcGKyvuSILW2rb3G7Xh+nexzLwhTpek6Ehxd6IjvHePg=="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -4135,14 +3705,6 @@
         "read-pkg": "^3.0.0",
         "shell-quote": "^1.6.1",
         "string.prototype.padend": "^3.0.0"
-      }
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -4202,19 +3764,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "1.1.1"
-      }
-    },
-    "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4230,35 +3779,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "openssl-self-signed-certificate": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/openssl-self-signed-certificate/-/openssl-self-signed-certificate-1.1.6.tgz",
-      "integrity": "sha1-nTpHdrGlfphHNQOSEUrS+RWoPdQ="
-    },
-    "opn": {
-      "version": "5.3.0",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-      "requires": {
-        "is-wsl": "^1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        }
       }
     },
     "optionator": {
@@ -4285,7 +3805,7 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
     "os-homedir": {
@@ -4309,11 +3829,6 @@
       "requires": {
         "shell-quote": "^1.4.2"
       }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.3.0",
@@ -4344,12 +3859,12 @@
     },
     "pako": {
       "version": "1.0.10",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha1-Qyi621CGpCaqkPVBl31JVdpclzI="
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
     },
     "parents": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/parents/-/parents-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "requires": {
         "path-platform": "~0.11.15"
@@ -4357,8 +3872,8 @@
     },
     "parse-asn1": {
       "version": "5.1.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/parse-asn1/-/parse-asn1-5.1.5.tgz",
-      "integrity": "sha1-ADJxND2ljclMrOSU+u89IUfs6g4=",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "requires": {
         "asn1.js": "^4.0.0",
         "browserify-aes": "^1.0.0",
@@ -4385,8 +3900,8 @@
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo="
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -4426,8 +3941,13 @@
     },
     "path-platform": {
       "version": "0.11.15",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/path-platform/-/path-platform-0.11.15.tgz",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
+    },
+    "path-to-regexp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
     },
     "path-type": {
       "version": "3.0.0",
@@ -4439,8 +3959,8 @@
     },
     "pbkdf2": {
       "version": "3.0.17",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -4549,7 +4069,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
@@ -4581,12 +4101,13 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "requires": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -4628,26 +4149,26 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -4658,31 +4179,9 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
-    "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
-        "unpipe": "1.0.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      }
-    },
     "read-only-stream": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "requires": {
         "readable-stream": "^2.0.2"
@@ -4860,23 +4359,6 @@
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
-    "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-      "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "requires": {
-        "rc": "^1.0.1"
-      }
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4892,7 +4374,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -4945,15 +4428,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
       "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA=="
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/rimraf/-/rimraf-2.7.1.tgz",
@@ -4964,8 +4438,8 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -5409,89 +4883,25 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
-    "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+    "serve-handler": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.2.tgz",
+      "integrity": "sha512-RFh49wX7zJmmOVDcIjiDSJnMH+ItQEvyuYLYuDBVoA/xmQSCuj+uRmk1cmBB5QQlI3qOiWKp6p4DUGY+Z5AB2A==",
       "requires": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        }
-      }
-    },
-    "serve": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-6.5.8.tgz",
-      "integrity": "sha512-GZYlJz7f6E7Xq6xbg1rTSvQQV9x4v/yYB/sum6egzSBLa/mdk1PViDSX2JvL0Me83sxu3JpEpQELfakDKbGcrw==",
-      "requires": {
-        "args": "4.0.0",
-        "basic-auth": "2.0.0",
-        "bluebird": "3.5.1",
-        "boxen": "1.3.0",
-        "chalk": "2.4.1",
-        "clipboardy": "1.2.3",
-        "dargs": "5.1.0",
-        "detect-port": "1.2.3",
-        "filesize": "3.6.1",
-        "fs-extra": "6.0.1",
-        "handlebars": "4.0.11",
-        "ip": "1.1.5",
-        "micro": "9.3.1",
-        "micro-compress": "1.0.0",
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
-        "node-version": "1.1.3",
-        "openssl-self-signed-certificate": "1.1.6",
-        "opn": "5.3.0",
+        "minimatch": "3.0.4",
         "path-is-inside": "1.0.2",
-        "path-type": "3.0.0",
-        "send": "0.16.2",
-        "update-check": "1.5.1"
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
       }
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -5511,15 +4921,10 @@
         }
       }
     },
-    "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-    },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -5527,7 +4932,7 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "requires": {
         "json-stable-stringify": "~0.0.0",
@@ -5568,11 +4973,12 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "simple-concat": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/simple-concat/-/simple-concat-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "slice-ansi": {
@@ -5807,15 +5213,10 @@
         }
       }
     },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/stream-browserify/-/stream-browserify-2.0.2.tgz",
-      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
@@ -5823,7 +5224,7 @@
     },
     "stream-combiner2": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "requires": {
         "duplexer2": "~0.1.0",
@@ -5832,8 +5233,8 @@
     },
     "stream-http": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/stream-http/-/stream-http-3.1.0.tgz",
-      "integrity": "sha1-Ivsz/ptAVrTsz1i9j0AMS5k//lc=",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
+      "integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
       "requires": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
@@ -5843,8 +5244,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -5855,8 +5256,8 @@
     },
     "stream-splicer": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/stream-splicer/-/stream-splicer-2.0.1.tgz",
-      "integrity": "sha1-CxO37itax+BgmnRj2DiZWJo2P80=",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.2"
@@ -5884,6 +5285,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -5911,6 +5313,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
       }
@@ -5920,19 +5323,15 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "subarg": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/subarg/-/subarg-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "requires": {
         "minimist": "^1.1.0"
@@ -5948,8 +5347,8 @@
     },
     "syntax-error": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/syntax-error/-/syntax-error-1.4.0.tgz",
-      "integrity": "sha1-LZ1P9cBkrLcRWUo+O5UFStUdkHw=",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "requires": {
         "acorn-node": "^1.2.0"
       }
@@ -5966,14 +5365,6 @@
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
-      }
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "requires": {
-        "execa": "^0.7.0"
       }
     },
     "text-table": {
@@ -5998,7 +5389,7 @@
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "requires": {
         "process": "~0.11.0"
@@ -6046,8 +5437,8 @@
     },
     "tty-browserify": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/tty-browserify/-/tty-browserify-0.0.1.tgz",
-      "integrity": "sha1-PwUlHuF5BN/QZ3VGZw25ZRaCuBE="
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -6063,32 +5454,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "optional": true,
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
-    },
     "umd": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/umd/-/umd-3.0.3.tgz",
-      "integrity": "sha1-qp/mU8QrkJdnhInAEACstp8LJs8="
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow=="
     },
     "undeclared-identifiers": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
-      "integrity": "sha1-klTB03vawKwrUt5LZyJ5LSqR4w8=",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+      "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
       "requires": {
         "acorn-node": "^1.3.0",
         "dash-ast": "^1.0.0",
@@ -6104,49 +5478,22 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -6189,19 +5536,10 @@
       }
     },
     "upath": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
-    },
-    "update-check": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.1.tgz",
-      "integrity": "sha512-M3rjq5KwSrWZrm2GVPIQIF+NXpIn5I9mIV67gGoydptQvzRjLp9ZbM6ctFJeNuaWSm5+mNP7aInELjSiLcIw6A==",
-      "requires": {
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0"
-      }
     },
     "urix": {
       "version": "0.1.0",
@@ -6211,7 +5549,7 @@
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/url/-/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "requires": {
         "punycode": "1.3.2",
@@ -6220,7 +5558,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
@@ -6263,15 +5601,10 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
     "vm-browserify": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-kayo-cache/vm-browserify/-/vm-browserify-1.1.0.tgz",
-      "integrity": "sha1-vXbWojMj4sqP+hICjcBFWcdfkBk="
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
     },
     "watch-run": {
       "version": "1.2.5",
@@ -6922,25 +6255,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-      "requires": {
-        "string-width": "^2.1.1"
-      }
-    },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "optional": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -6976,27 +6290,8 @@
     "yallist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "optional": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "optional": true
-        }
-      }
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "dev": true
     },
     "yauzl": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vizard",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "An automated visual regression testing framework",
   "main": "src/index.js",
   "bin": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "author": "Streamotion Web Developers",
   "license": "MIT",
   "dependencies": {
+    "babelify": "^10.0.0",
     "browserify": "^16.5.0",
     "envify": "^4.1.0",
     "get-port": "^3.2.0",
@@ -51,7 +52,7 @@
     "puppeteer-core": "^1.20.0",
     "recursive-readdir": "^2.2.2",
     "rimraf": "^2.7.1",
-    "serve": "^6.5.8"
+    "serve-handler": "^6.1.2"
   },
   "devDependencies": {
     "eslint": "^4.9.0",

--- a/src/framework/index.js
+++ b/src/framework/index.js
@@ -10,10 +10,13 @@ const toolkit = require('./toolkit');
         vizardInstance.registerSuite({suiteName, testCreator, suiteOptions});
     };
 
-    // it('focused', function (target) {...});
-    window.it = function (testName, testRunner, testOptions) {
+    // test('focused', function (target) {...});
+    window.test = function (testName, testRunner, testOptions) {
         vizardInstance.registerTestCase({testName, testRunner, testOptions});
     };
+
+    // Alias it to test
+    window.it = window.test;
 
     window._registerTests = () => vizardInstance.registerAllTests();
     window._runTests = (props) => vizardInstance.runTests(props);

--- a/src/framework/vizard.js
+++ b/src/framework/vizard.js
@@ -15,7 +15,7 @@ VizardInstance.prototype.registerAllTests = function () {
         // Attach the current suite name to the class so when we call `it` we can work out which test we're under
         this.currentSuiteName = suiteName;
 
-        // Calls the function which will do a bunch of `it('foo', function () {...});
+        // Calls the function which will do a bunch of `test('foo', function () {...});
         testCreator();
     });
 };

--- a/src/scripts/make-golden.js
+++ b/src/scripts/make-golden.js
@@ -49,6 +49,8 @@ module.exports = async function makeGolden({
     }
 
     // We always want to clean up
-    await Promise.all(browsers.map((browser) => browser.close()));
-    server.stop();
+    await Promise.all([
+        ...browsers.map((browser) => browser.close()),
+        new Promise((resolve) => void server.close(resolve)),
+    ]);
 };

--- a/src/scripts/test.js
+++ b/src/scripts/test.js
@@ -204,8 +204,10 @@ module.exports = async function test({
     }
 
     // We always want to clean up
-    await Promise.all(browsers.map((browser) => browser.close()));
-    server.stop();
+    await Promise.all([
+        ...browsers.map((browser) => browser.close()),
+        new Promise((resolve) => void server.close(resolve)),
+    ]);
 
     const testPermutations = getAllTestPermutations({testsByViewport});
 

--- a/src/util/compile-tests.js
+++ b/src/util/compile-tests.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const fsExtra = require('fs-extra');
 const browserify = require('browserify');
+const envify = require('envify/custom');
 const recursive = require('recursive-readdir');
 const logger = require('./logger');
 
@@ -28,6 +29,8 @@ module.exports = async function compileTests({
         const writeablePipeline = browserify(testFilePaths, {
             standalone: BUNDLE_NAME,
         })
+            .transform('babelify')
+            .transform(envify({NODE_ENV: process.env.NODE_ENV || 'development'}))
             .bundle()
             .pipe(fs.createWriteStream(bundleOutfilePath));
 

--- a/src/util/setup-puppeteer.js
+++ b/src/util/setup-puppeteer.js
@@ -1,7 +1,8 @@
 const path = require('path');
 const {execSync} = require('child_process');
+const http = require('http');
 const puppeteer = require('puppeteer-core');
-const serve = require('serve');
+const serveHandler = require('serve-handler');
 const portfinder = require('portfinder');
 const times = require('lodash/times');
 const takeScreenshot = require('./take-screenshot');
@@ -41,7 +42,10 @@ module.exports = async function setupPuppeteer(config) {
     logger.info(`Setting up server on port ${port}`);
 
     // If the user supplied a testRunnerHtml via config, run in their cwd
-    const server = await serve(testRunnerHtml ? process.cwd() : path.join(__dirname, '..', '..'), {port, silent: true, clipless: true});
+    const serveHandlerOptions = {public: testRunnerHtml ? process.cwd() : path.join(__dirname, '..', '..')};
+    const server = http.createServer((req, res) => serveHandler(req, res, serveHandlerOptions));
+
+    await new Promise((resolve) => void server.listen(port, resolve));
 
     const puppeteerOptions = {
         args: ['--no-sandbox', '--disable-setuid-sandbox'],


### PR DESCRIPTION
This PR adds Travis CI config for automated deployment to npmjs.

Before merging this PR, replace my `email` and `api_key` with [yours](https://docs.travis-ci.com/user/deployment/npm/#npm-auth-token).

Before tagging for the first time, sign in to [Travis CI](https://travis-ci.org/) and add this repo.

Bump the package version before tagging, because version 0.0.1 is already [published](https://www.npmjs.com/package/vizard).
